### PR TITLE
add BUMPSOLVER Orgs UX

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -22,7 +22,12 @@ import bumpsReducer from './bumps';
 import * as bumps from './bumps';
 export {bumps as bumps};
 
+import solversReducer from './solvers';
+import * as solvers from './solvers';
+export {solvers as solvers};
+
 export default createStore(combineReducers({
   auth: authReducer,
   bumps: bumpsReducer,
+  solvers: solversReducer,
 }), composeEnhancers(applyMiddleware(thunk, logger)));

--- a/app/src/solvers/index.js
+++ b/app/src/solvers/index.js
@@ -1,0 +1,40 @@
+import Duck from '../duck';
+
+const initialState = [{
+  orgName: 'Solver1',
+}, {
+  orgName: 'Solver2',
+}, {
+  orgName: 'Solver3',
+}];
+
+const duck = new Duck(
+  'solvers',
+  initialState,
+  (state) => state.solvers
+);
+
+//
+// Selectors
+//
+export const getSolvers = duck.selector((state) => state);
+
+//
+// Private actions
+//
+
+//
+// Public actions
+//
+export const reset = duck.action('RESET_SOLVERS');
+export const addSolver = duck.action('ADD_SOLVER');
+
+//
+// Reducer
+//
+export default duck.reducer({
+  [reset]: () => initialState,
+  [addSolver]: (state, action) => state.concat([{
+    orgName: action.payload.orgName,
+  }]),
+});

--- a/app/test/src/index.js
+++ b/app/test/src/index.js
@@ -11,6 +11,10 @@ describe('app', () => {
   });
 
   it('should export the bumps duck', () => {
-    app.auth.should.be.ok;
+    app.bumps.should.be.ok;
+  });
+
+  it('should export the solvers duck', () => {
+    app.solvers.should.be.ok;
   });
 });

--- a/app/test/src/solvers/index.js
+++ b/app/test/src/solvers/index.js
@@ -1,0 +1,64 @@
+import _ from 'lodash';
+import * as solvers from '../../../src/solvers';
+import reducer from '../../../src/solvers';
+import {
+  createStore,
+  combineReducers,
+} from 'redux';
+
+let states;
+const store = createStore(combineReducers({
+  solvers: reducer,
+}));
+store.subscribe(() => {
+  states.push(store.getState());
+});
+async function reset({actions}) {
+  store.dispatch(solvers.reset());
+  await actions.reduce(async (promise, action) => {
+    await promise;
+    await store.dispatch(action);
+  }, Promise.resolve());
+  states = [];
+}
+
+const initialSolvers = [{
+  orgName: 'Solver1',
+}, {
+  orgName: 'Solver2',
+}, {
+  orgName: 'Solver3',
+}];
+const orgName = 'solverX';
+const solver = {
+  orgName,
+};
+
+describe('solvers', () => {
+  describe('with the initial state', () => {
+    before(() => {
+      states = [
+        store.getState(),
+      ];
+    });
+
+    it('should have the initial solvers', () => {
+      solvers.getSolvers(states[0]).should.eql(initialSolvers);
+    });
+
+    describe('then addSolver', () => {
+      before(async () => {
+        await reset({
+          actions: [],
+        });
+        await store.dispatch(solvers.addSolver({
+          orgName,
+        }));
+      });
+
+      it('should add a solver', () => {
+        solvers.getSolvers(states[0]).should.eql(initialSolvers.concat(solver));
+      });
+    });
+  });
+});

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,9 @@
     "paper-fab": "PolymerElements/paper-fab#^1.2.1",
     "paper-card": "PolymerElements/paper-card#^1.1.4",
     "paper-spinner": "PolymerElements/paper-spinner#^1.2.1",
-    "paper-dialog": "PolymerElements/paper-dialog#^1.1.0"
+    "paper-dialog": "PolymerElements/paper-dialog#^1.1.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.2",
+    "paper-toast": "PolymerElements/paper-toast#^1.3.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/ui/src/bump/bump-list-page.html
+++ b/ui/src/bump/bump-list-page.html
@@ -4,22 +4,43 @@
 <link rel="import" href="../../../bower_components/paper-card/paper-card.html">
 <link rel="import" href="../../../bower_components/paper-fab/paper-fab.html">
 <link rel="import" href="../../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../../../bower_components/paper-toast/paper-toast.html">
 <link rel="import" href="../app-styles.html">
 
 <dom-module id="bump-list-page">
   <template>
     <style include="app-styles">
-       .flex_vertical {
+       #listContainer {
         @apply --layout-vertical;
       }
+      #toastContainer {
+        @apply --layout-horizontal;
+        align-items: center;
+        justify-content: flex-end;
+      }
+      .flexchild {
+        @apply --layout-flex;
+        /*@apply(--layout-start);*/
+      }
+      .flexbutton {
+        @apply --layout-end-justified;
+        @apply --layout-center;
+        height: 40px;
+      }
     </style>
-    <div class="flex_vertical">
+    <div id="pageContainer">
+    <paper-toast id="toast" dynamic-align=true vertical-align="top" horizontal-align="center" duration=10000 text="We're scouting for problem solving organisations (BUMPSOLVERS). Know any?">
+        <paper-button id="addSolverBtn" on-tap="_tapViewSolvers">View</paper-button>
+        <paper-button id="closeToast" flat on-tap="_tapCloseToast">Not now</paper-button>
+    </paper-toast>  
+    <div id="listContainer">    
      <template is="dom-repeat" items="[[bumps]]">
         <paper-card id="[[_bumpId(item)]]" heading="[[item.name]]">
         </paper-card>
       </template>
     </div>
-    <paper-fab id="addBumpBtn" label="+B" on-tap="_tapAddBump"></paper-fab>
+    <paper-fab id="addBumpBtn" label="+" on-tap="_tapAddBump"></paper-fab>
     <paper-dialog id="signInDialog" modal>
       <h2>Add BUMPS</h2>
       <p>Please sign-in to add new BUMPS.</p>
@@ -29,6 +50,7 @@
         <paper-button id='cancelBtn' class="cancel" on-tap="_tapCancel">Cancel</paper-button>
       </div>
     </paper-dialog>
+    </div> <!-- container -->
   </template>
   <script>
     Polymer({
@@ -39,6 +61,10 @@
           type: Boolean,
           value: false,
         },
+      },
+      ready: function() {
+        this.$.toast.fitInto = this.$.listContainer;
+        this.$.toast.open();
       },
       _bumpId: function(bump) {
         return 'bump' + bump.id;
@@ -58,6 +84,13 @@
       },
       _tapCancel: function() {
         this.$.signInDialog.close();        
+      },
+      _tapViewSolvers: function() {
+        console.log("bump_page: _tapViewSolvers");
+        this.fire('request-viewSolvers');
+      },
+      _tapCloseToast: function() {
+        this.$.toast.close();
       },
     });
   </script>

--- a/ui/src/solvers/add-solver-page.html
+++ b/ui/src/solvers/add-solver-page.html
@@ -1,0 +1,73 @@
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../app-styles.html">
+
+<dom-module id="add-solver-page">
+  <template>
+    <style include="app-styles">
+      #card-location {
+        width: 500px;
+        margin: auto;
+      }
+      #contents {
+        display: block;
+        margin: 20px;
+        border: 1px;
+        border-color: black;
+      }
+    </style>
+  <div id="contents">
+    <!-- <paper-card> -->
+      <div class="card-content">
+        <h1>Add BUMPSOLVER</h1>
+        <p>We are scouting for organistions engaged in problem solving. This can be private or public, for-profit or not-for-profit.</p>
+        <paper-input id="orgName" label="Org Name"></paper-input>
+        <paper-input id="orgURL" label="Website"></paper-input>
+        <paper-input id="contactName" label="Contact Name"></paper-input>
+        <paper-input id="contactEmail" label="Contact Email"></paper-input>
+        <paper-input id="tags" label="tags"></paper-input>
+        <p>Use tags to help define the org e.g. charity, uk, london, cancer</p>
+      </div>
+      <div class="card-actions">
+        <paper-button id="createBtn" on-tap="_tapCreate">Create</paper-button>
+        <paper-button id="cancelBtn" class="cancel" on-tap="_tapCancel">Cancel</paper-button>
+      </div>
+ <!--   </paper-card> -->
+    </div> 
+  </template>
+  <script>
+    Polymer({
+      is: 'add-solver-page',
+      _tapCreate: function() {
+        console.log("add-solver-page: _tapCreate");
+        var orgName = this.$.orgName.value;
+        var orgURL = this.$.orgURL.value;
+        var contactName = this.$.contactName.value;
+        var contactEmail = this.$.contactEmail.value;
+        var tags = this.$.tags.value;
+        //clear fields for now...but...
+        //eventuall we need to wait for a confirmation from the server
+        //because if error is received user should see submitted data
+        this.$.orgName.value = '';
+        this.$.orgURL.value = '';
+        this.$.contactName.value = '';
+        this.$.contactEmail.value = '';
+        this.$.tags.value = '';
+        this.fire("solver-create", {
+          orgName : orgName,
+          orgURL : orgURL,
+          contactName : contactName,
+          contactEmail : contactEmail,
+          tags : tags,
+        });
+       },
+      _tapCancel: function() {
+        console.log("add-solver-page: _tapCancel");
+        this.fire("solver-create-cancel");
+      },
+   });
+  </script>
+</dom-module>
+

--- a/ui/src/solvers/solvers-container.html
+++ b/ui/src/solvers/solvers-container.html
@@ -1,0 +1,66 @@
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/iron-pages/iron-pages.html">
+<link rel="import" href="../../../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="../redux-behavior.html">
+<link rel="import" href="./add-solver-page.html">
+<link rel="import" href="./solvers-list-page.html">
+
+
+<dom-module id="solvers-container">
+  <template>
+    <iron-pages id="pageSelector" attr-for-selected="id" selected="[[displayPage]]" fallback-selection="pathWarning">
+      <solvers-list-page id="solversListPage" solvers="[[solvers]]" is-signed-in="[[isSignedIn]]"></solvers-list-page>
+      <add-solver-page id="addSolverPage"></add-solver-page>
+       <p id="pathWarning">Solvers-Container. We can't find that page. :-(</p>
+    </iron-pages>
+  </template>
+  <script>
+    Polymer({
+      is: 'solvers-container',
+      behaviors: [ReduxBehavior],
+      actions: {
+        addSolver: app.solvers.addSolver,
+      },
+      properties: {
+        displayPage: {
+          type: String,
+          value: "solversListPage",
+          //readOnly: true, 
+        },
+        solvers: {
+          type: Array,
+          statePath: app.solvers.getSolvers,
+        },
+        isSignedIn: {
+          type: Boolean,
+          statePath: app.auth.isSignedIn,
+        }
+      },
+      //Event listeners
+      listeners: {
+        'request-addsolver-form': "_addSolverPage", //from solver-list-page
+        'solver-create':"_createSolver", //from add-solver-page
+        'solver-create-cancel':"_createSolverCancel", //from add-solver-page
+        //'request-signin' from add-solver-page will be ignored (handled by our parent)
+      },
+      _addSolverPage: function () {
+        console.log("solversContainer: _addSolverPage");
+        this.displayPage="addSolverPage";
+      },
+      _createSolver: function (event) {
+        console.log("solversContainer: _createSolver");
+        this.displayPage="solversListPage";
+        return this.dispatch(
+         'addSolver', {
+            orgName: event.detail.orgName
+          }
+        );
+      },
+      _createSolverCancel: function () {
+        console.log("solversContainer: _createSolverCancel");
+        this.displayPage="solversListPage";
+      },
+    });
+  </script>
+</dom-module>
+ 

--- a/ui/src/solvers/solvers-list-page.html
+++ b/ui/src/solvers/solvers-list-page.html
@@ -1,0 +1,71 @@
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../../bower_components/paper-fab/paper-fab.html">
+<link rel="import" href="../../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../app-styles.html">
+
+<dom-module id="solvers-list-page">
+  <template>
+    <style include="app-styles">
+       .flex_vertical {
+        @apply --layout-vertical;
+      }
+      .flex_horizontal {
+        @apply --layout-horizontal;
+      }
+    </style>
+    <h1>BUMPSOLVERS</h1>
+    <p>BUMPSOLVERS are problem solving organistions. They play an important part in solving BUMPS.</p>
+    <p>These organisations can be public or private, non-profit or for-profit. Examples include: a local charity, local goverment dept, a startup, a major international corporation.</p>
+    <div class="flex_vertical">
+     <template is="dom-repeat" items="[[solvers]]">
+        <paper-card id="[[item.orgName]]" heading="[[item.orgName]]">
+        </paper-card>
+      </template>
+    </div>
+    <paper-fab id="addSolverBtn" label="+" on-tap="_tapAddSolver"></paper-fab>
+    <paper-dialog id="signInDialog" modal>
+      <h2>Add Solvers</h2>
+      <p>Please sign-in to register new Solvers.</p>
+      <p>It only takes a minute!</p>
+      <div class="buttons">
+        <paper-button id='signInBtn' dialog-confirm autofocus on-tap="_tapSignIn">Sign In</paper-button>
+        <paper-button id='cancelBtn' class="cancel" on-tap="_tapCancel">Cancel</paper-button>
+      </div>
+    </paper-dialog>
+  </template>
+  <script>
+    Polymer({
+      is: 'solvers-list-page',
+      properties: {
+        solvers: Array,
+        isSignedIn: {
+          type: Boolean,
+          value: false,
+        },
+      },
+      _solverId: function(solver) {
+        return 'solver' + solver.id;
+      },
+       _tapAddSolver: function() {
+        console.log("solvers-list-page: _tapAddSolver");
+        if(!this.isSignedIn) {
+            this.$.signInDialog.open();
+        } else {
+            this.fire('request-addsolver-form');
+        }
+      },
+      _tapSignIn: function() {
+        console.log("solvers-list-page: _tapSignIn");
+        this.$.signInDialog.close();
+        this.fire('request-signin');
+      },
+      _tapCancel: function() {
+        this.$.signInDialog.close();        
+      },
+    });
+  </script>
+</dom-module>

--- a/ui/src/ui-app.html
+++ b/ui/src/ui-app.html
@@ -7,6 +7,7 @@
 <link rel="import" href="./auth/auth-container.html">
 <link rel="import" href="./bump/bumps-container.html">
 <link rel="import" href="./auth/signout-page.html">
+<link rel="import" href="./solvers/solvers-container.html">
 
 <dom-module id="ui-app">
   <template>
@@ -25,6 +26,7 @@
        <bumps-container id="bumpsContainer"></bumps-container>
        <auth-container id="authContainer"></auth-container>
        <signout-page id="signOutPage"></signout-page>
+       <solvers-container id="solversContainer"></solvers-container>
        <p id="pathWarning">Sorry. We can't find that page. :-(</p>
     </iron-pages>
   </template>
@@ -66,6 +68,7 @@
         'request-signout': "_signOut", //from bump-appheader
         'signout-confirmed' : '_signOutConfirmed', //from sign-out
         'signout-cancelled' : '_signOutCancelled', //from sign-out
+        'request-viewSolvers' : '_viewSolvers', //from bump-list-page
       },
       //listener handlers
       _displayMenu: function () {
@@ -96,7 +99,11 @@
           if(this.isSignedIn) {
             console.log("ui-app: IsSignedIn= " + this.isSignedIn)
             this.displayPage="bumpsContainer";
-           }
+          }
+      },
+      _viewSolvers: function () {
+        console.log("ui-app: _viewSolvers");
+        this.displayPage = "solversContainer";
       },
     });
   </script>

--- a/ui/test/helpers/stubs.html
+++ b/ui/test/helpers/stubs.html
@@ -30,4 +30,13 @@ app.helpers.stub(['bumps'], 'getList', []);
 // actions
 app.helpers.stub(['bumps'], 'add');
 
+//
+// solvers
+//
+
+// selectors
+app.helpers.stub(['solvers'], 'getSolvers', []);
+
+// actions
+app.helpers.stub(['solvers'], 'addSolver');
 </script>

--- a/ui/test/src/solvers/add-solver-page.html
+++ b/ui/test/src/solvers/add-solver-page.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <script src="../../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../../bower_components/web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../../helpers/common.html">
+    <link rel="import" href="../../../src/solvers/add-solver-page.html">
+  </head>
+  <body>
+
+    <test-fixture id="default">
+      <template>
+        <add-solver-page></add-solver-page>
+      </template>
+    </test-fixture>
+
+    <script>
+    var addSolverPage;
+    describe('addSolverPage', function(){
+      before(function() {
+        addSolverPage = fixture('default');
+      });
+      describe('create solver form', function(){
+        it('should have a create button', function() {
+          expect(addSolverPage.$.createBtn).to.be.ok;
+        });
+         it('should have a cancel button', function() {
+          expect(addSolverPage.$.cancelBtn).to.be.ok;
+       });
+       it('should have a orgName field', function() {
+          expect(addSolverPage.$.orgName).to.be.ok;
+       });
+       it('should have a orgURL field', function() {
+          expect(addSolverPage.$.orgURL).to.be.ok;
+       });
+       it('should have a contactName field', function() {
+          expect(addSolverPage.$.contactName).to.be.ok;
+       });
+       it('should have a contactEmail field', function() {
+          expect(addSolverPage.$.contactEmail).to.be.ok;
+       });
+       it('should have a tags field', function() {
+          expect(addSolverPage.$.tags).to.be.ok;
+       });
+      });
+      describe('when the create button is clicked', function() {
+          it('should clear the text fields and fire a solver-create event', function(done) {
+              addSolverPage.$.orgName.value = 'new solver';
+              addSolverPage.$.orgURL.value = 'www.bumpsolver.com'; 
+              addSolverPage.$.contactName.value = 'bumpivore';
+              addSolverPage.$.contactEmail.value = 'bumpivore@bumpsolver.com';
+              addSolverPage.$.tags.value = 'bump solver';                           
+              addSolverPage.addEventListener('solver-create', function(event) {
+                event.detail.should.eql({
+                 orgName: 'new solver',
+                 orgURL: 'www.bumpsolver.com',
+                 contactName: 'bumpivore',
+                 contactEmail: 'bumpivore@bumpsolver.com',
+                 tags: 'bump solver',
+              });
+              addSolverPage.$.orgName.value = '';
+              addSolverPage.$.orgURL.value = ''; 
+              addSolverPage.$.contactName.value = '';
+              addSolverPage.$.contactEmail.value = '';
+              addSolverPage.$.tags.value = '';   
+              done();
+            });
+            addSolverPage.$.createBtn.click();
+          });
+      });
+      describe('when the cancel button is clicked', function() {
+          it('should fire a solver-create-cancel event', function(done) {
+              addSolverPage.addEventListener('solver-create-cancel', function(event) {
+              done();
+            });
+            addSolverPage.$.cancelBtn.click();
+          });
+      });
+    }); 
+
+    </script>
+  </body>
+</html>

--- a/ui/test/src/solvers/solvers-container.html
+++ b/ui/test/src/solvers/solvers-container.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <script src="../../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../../bower_components/web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../../helpers/common.html">
+    <link rel="import" href="../../../src/solvers/solvers-container.html">
+  </head>
+  <body>
+    <test-fixture id="fixture-solversContainer">
+      <template>
+        <solvers-container></solvers-container>
+      </template>
+    </test-fixture>
+   <script>
+   var solversContainer;
+
+   describe('solvers-container ', function() {
+      describe('when signedIn', function() {
+        beforeEach(function(done) {
+          app.auth.isSignedIn.value = true;
+          app.solvers.getSolvers.value = [{
+            orgName: 'name',
+          }];
+          solversContainer = fixture('fixture-solversContainer');
+          flush(done);
+        });
+        it('should configure the solversListPage isSignedIn attribute', function() {
+          solversContainer.$.solversListPage.isSignedIn.should.be.true;
+        });
+        it('should configure the solversListPage solvers array', function() {
+          solversContainer.$.solversListPage.solvers.should.eql([{
+             orgName: 'name',
+          }]);
+        });
+      });
+      describe('Event Listeners', function() {
+        beforeEach(function(done) {
+          app.helpers.reset();
+          solversContainer = fixture('fixture-solversContainer');
+          flush(done);
+        });
+        it('should listen for a request-addSolver-form event', function(done) {
+          solversContainer.addEventListener('request-addsolver-form', function(event) {
+              done();
+          });
+          solversContainer.fire('request-addsolver-form');
+        });
+        it('should listen for a solver-create', function(done) {
+          solversContainer.addEventListener('solver-create', function(event) {
+             event.detail.should.eql({
+                name: 'new solver',
+              });
+              done();
+          });
+          solversContainer.fire('solver-create', {
+              name: 'new solver',
+              });
+        });
+        it('should listen for a solver-create-cancel event', function(done) {
+          solversContainer.addEventListener('solver-create-cancel', function(event) {
+              done();
+          });
+          solversContainer.fire('solver-create-cancel');
+        });
+      });//End of Listeners
+      describe('Action Dispatchers', function() {
+        beforeEach(function(done) {
+          app.helpers.reset();
+          solversContainer = fixture('fixture-solversContainer');
+          flush(done);
+        });
+        it('should dispatch an addSolver action when a solver-create event is received', function() {
+           solversContainer.$.solversListPage.fire('solver-create', {
+               orgName: 'new solver',
+            });
+            app.solvers.addSolver.should.have.been.calledWith({orgName: 'new solver'});
+            store.dispatch.should.have.been.calledWith(app.solvers.addSolver.value);
+        });
+      });      
+   });
+   </script>
+  </body>
+</html>

--- a/ui/test/src/solvers/solvers-list-page.html
+++ b/ui/test/src/solvers/solvers-list-page.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <script src="../../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../../bower_components/web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../../helpers/common.html">
+    <link rel="import" href="../../../src/solvers/solvers-list-page.html">
+  </head>
+  <body>
+
+  <test-fixture id="default">
+     <template is="dom-template">
+        <solvers-list-page solvers="[[solvers]]"></solvers-list-page>
+      </template>
+   </test-fixture>
+   <test-fixture id="whenSignedOut">
+      <template>
+        <solvers-list-page is-signed-out=false></solvers-list-page>
+      </template>
+   </test-fixture> 
+   <test-fixture id="whenSignedIn">
+      <template>
+        <solvers-list-page is-signed-in=true></solvers-list-page>
+      </template>
+   </test-fixture>    
+
+  <script>
+  var solversList
+  describe('solvers-list-page', function(){
+    describe('under default conditions', function(){
+      beforeEach(function(done) {
+        solversList = fixture('default', {
+          solvers: [{
+            orgName: 'solver1',
+          }, {
+            orgName: 'solver2',
+          }, {
+            orgName: 'solver3',
+          }]
+        });
+        flush(done);
+      });
+      it('should contain an addSolver button', function() {
+          expect(solversList.$.addSolverBtn).to.be.ok;
+      });
+      it('should display the solvers', function() {
+          solversList.$$('#solver1').heading.should.eql('solver1');
+          solversList.$$('#solver2').heading.should.eql('solver2');
+          solversList.$$('#solver3').heading.should.eql('solver3');
+      });
+      it('should contain a closed sign-in Digalog', function() {
+          expect(solversList.$.signInDialog).to.be.ok;
+          expect(solversList.$.signInBtn).to.be.ok;
+          expect(solversList.$.cancelBtn).to.be.ok;
+          expect(solversList.$.signInDialog.opened).to.be.false;
+      });
+    });
+    describe('when signed-out', function(){
+      before(function(done) {
+        solversList = fixture('whenSignedOut');
+        flush(done);
+      });
+      describe('when the addSolver button is clicked', function() {
+         it('should display a signInDialog', function() {
+           solversList.$.addSolverBtn.click();
+           expect(solversList.$.signInDialog.opened).to.be.true;
+         });
+      });
+    });
+    describe('when signInDialog displayed', function(){
+      beforeEach(function(done) {
+        solversList = fixture('whenSignedOut');
+        solversList.$.addSolverBtn.click();
+        flush(done);
+      });
+      describe('when the dialog sign-in button is clicked', function() {
+         it('should fire a request-signin event', function(done) {
+           solversList.addEventListener('request-signin', function(event) {
+              done();
+           });
+           solversList.$.signInBtn.click();
+         });
+      });
+      describe('when the dialog cancel button is clicked', function() {
+         it('should close the dialog', function(done) {
+           solversList.$.cancelBtn.click();
+           expect(solversList.$.signInDialog.opened).to.be.false;
+           done();
+         });
+      });
+    });
+    describe('when signed-in', function(){
+      before(function(done) {
+        solversList = fixture('whenSignedIn');
+        flush(done);
+      });
+      describe('when the addSolver button is clicked', function() {
+          it('should fire a request-addsolvers-form event', function(done) {
+            solversList.addEventListener('request-addsolver-form', function(event) {
+              expect(solversList.$.signInDialog.opened).to.be.false;
+              done();
+            });
+            solversList.$.addSolverBtn.click();
+          });
+      });
+    });  
+  });
+    </script>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,9 @@
+var path = require('path');
 module.exports = {
   entry: './app/index.js',
   output: {
     filename: 'bundle.js',
-    path: './ui/app',
+    path: path.resolve(__dirname, './ui/app'),
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Please Review.

Change summary: 
1. Ui: basic UX flow to enable adding of organisations to the app.
2. App: minimal redux parts necessary to support UX
3. default state (similar to how the bumps is currently implemented)
4. tests for all the above

Note: I've (temporarily) added a paper-toast element in the bumps-list that allows for us to access the organisation list (see attached image).  This may be removed once we have an app-menu implemented.

Ken
![howtoaccessthesolverslist](https://cloud.githubusercontent.com/assets/10337926/24225758/8500cf32-0f62-11e7-8b3b-bc0bc522cdd8.png)
